### PR TITLE
Bug Fix

### DIFF
--- a/src/main/java/me/totalfreedom/totalfreedommod/command/Command_cbtool.java
+++ b/src/main/java/me/totalfreedom/totalfreedommod/command/Command_cbtool.java
@@ -16,7 +16,7 @@ import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
-@CommandPermissions(level = Rank.NON_OP, source = SourceType.BOTH)
+@CommandPermissions(level = Rank.SUPER_ADMIN, source = SourceType.BOTH)
 @CommandParameters(description = "No Description Yet", usage = "/<command>")
 public class Command_cbtool extends FreedomCommand
 {


### PR DESCRIPTION
My logic on making /cbtool admin-only is that you require admin to use the blocked commands, which would make using this to use them pointless.